### PR TITLE
Pipeline Placeholder

### DIFF
--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -234,7 +234,7 @@ defmodule Macro do
 
   defp unpipe({op, line, args} = other, acc) when is_list(args) do
     segment =
-      case placeholder_position(args) do
+      case hole_position(args) do
         nil -> {other, 0}
         n -> {{op, line, List.delete_at(args, n)}, n}
       end
@@ -246,17 +246,11 @@ defmodule Macro do
     [{other, 0} | acc]
   end
 
-  defp placeholder_position(args) do
-    Enum.find_index(args, &is_placeholder/1)
-  end
+  defp hole_position(args), do: hole_position(args, 0)
 
-  defp is_placeholder({:_, _, _}) do
-    true
-  end
-
-  defp is_placeholder(_) do
-    false
-  end
+  defp hole_position([{:_, _, _} | _tail], n), do: n
+  defp hole_position([_head | tail], n), do: hole_position(tail, n + 1)
+  defp hole_position([], _), do: nil
 
   @doc """
   Pipes `expr` into the `call_args` at the given `position`.

--- a/lib/elixir/lib/macro.ex
+++ b/lib/elixir/lib/macro.ex
@@ -232,8 +232,30 @@ defmodule Macro do
     unpipe(right, unpipe(left, acc))
   end
 
+  defp unpipe({op, line, args} = other, acc) when is_list(args) do
+    segment =
+      case placeholder_position(args) do
+        nil -> {other, 0}
+        n -> {{op, line, List.delete_at(args, n)}, n}
+      end
+
+    [segment | acc]
+  end
+
   defp unpipe(other, acc) do
     [{other, 0} | acc]
+  end
+
+  defp placeholder_position(args) do
+    Enum.find_index(args, &is_placeholder/1)
+  end
+
+  defp is_placeholder({:_, _, _}) do
+    true
+  end
+
+  defp is_placeholder(_) do
+    false
   end
 
   @doc """

--- a/lib/elixir/test/elixir/kernel_test.exs
+++ b/lib/elixir/test/elixir/kernel_test.exs
@@ -1115,7 +1115,16 @@ defmodule KernelTest do
       assert [1] |> (&hd(&1)).() == 1
     end
 
+    test "with placeholder" do
+      assert 1 |> subtract(2, _) == 1
+      assert 1 |> subtract(_, 2) == -1
+
+      assert "hello" |> Regex.match?(~r/l{2}/, _)
+    end
+
     defp twice(a), do: a * 2
+
+    defp subtract(a, b), do: a - b
 
     defp local(list) do
       Enum.map(list, &(&1 * 2))

--- a/lib/elixir/test/elixir/macro_test.exs
+++ b/lib/elixir/test/elixir/macro_test.exs
@@ -853,6 +853,7 @@ defmodule MacroTest do
   test "unpipe/1" do
     assert Macro.unpipe(quote(do: foo)) == quote(do: [{foo, 0}])
     assert Macro.unpipe(quote(do: foo |> bar)) == quote(do: [{foo, 0}, {bar, 0}])
+    assert Macro.unpipe(quote(do: foo |> bar(1, _))) == quote(do: [{foo, 0}, {bar(1), 1}])
     assert Macro.unpipe(quote(do: foo |> bar |> baz)) == quote(do: [{foo, 0}, {bar, 0}, {baz, 0}])
   end
 


### PR DESCRIPTION
This PR enables underscore to serve as a placeholder for the result of the previous pipeline step. This allows the following syntax:

```elixir
"hello, world!
|> Regex.scan(~r/[a-zA-Z]+/, _)
```

Existing functionality is preserved.

